### PR TITLE
Anonymous page

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -182,6 +182,7 @@ struct thread {
 	/* 스레드가 소유한 전체 가상 메모리에 대한 테이블. */
 	/* Table for whole virtual memory owned by thread. */
 	struct supplemental_page_table spt;
+	void *stack_bottom;
 #endif
 
 	/* Owned by thread.c. */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -1,7 +1,7 @@
 #ifndef THREADS_THREAD_H
 #define THREADS_THREAD_H
 #define VM
-#define USERPROG
+
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -2,7 +2,11 @@
 #define USERPROG_PROCESS_H
 
 #include "threads/thread.h"
-
+struct container{
+    struct file *file;
+    off_t offset;
+    size_t page_read_bytes;
+};
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_);
 int process_exec (void *f_name);

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -193,12 +193,13 @@ page_fault (struct intr_frame *f) {
 		return;
 #endif
 
+	/* userprog 테스트 케이스 통과 위해 exit(-1)로 종료합니다. */
+	if ( fault_addr == NULL || !is_user_vaddr(fault_addr))
+		exit(-1);
+
 	/* 페이지 폴트 횟수를 셉니다. */
 	/* Count page faults. */
 	page_fault_cnt++;
-
-	/* userprog 테스트 케이스 통과 위해 exit(-1)로 종료합니다. */
-	exit(-1);
 
 	/* 폴트가 진짜 폴트인 경우 정보를 표시하고 종료합니다. */
 	/* If the fault is true fault, show info and exit. */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -578,7 +578,7 @@ static bool load(const char *file_name, struct intr_frame *if_) {
         printf("load: %s: open failed\n", file_name);
         goto done;
     }
-    t -> running = file_reopen(file);
+    t -> running = file;
     file_deny_write(t->running);
     lock_release(&filesys_lock);
 
@@ -654,7 +654,7 @@ static bool load(const char *file_name, struct intr_frame *if_) {
 done:
     /* 로드가 성공했든 실패했든 여기에 도착합니다. */
     /* We arrive here whether the load is successful or not. */
-    file_close(file);
+    //file_close(file); process_exit될떄 running file을 닫아줌
     return success;
 }
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -904,6 +904,7 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage, uint32_t 
         read_bytes -= page_read_bytes;
         zero_bytes -= page_zero_bytes;
         upage += PGSIZE;
+        ofs += page_read_bytes; /** Project 3: Anonymous Page - page_read_bytes 만큼 offset */
     }
     return true;
 }

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -901,7 +901,14 @@ static bool setup_stack(struct intr_frame *if_) {
      * TODO: If success, set the rsp accordingly.
      * TODO: You should mark the page is stack. */
     /* TODO: Your code goes here */
+    if (vm_alloc_page(VM_ANON | VM_MARKER_0, stack_bottom, 1)) {  // MARKER_0로 STACK에 있는 것을 표시
+        success = vm_claim_page(stack_bottom);
 
+        if (success) {
+            if_->rsp = USER_STACK;
+            thread_current()->stack_bottom = stack_bottom;
+        }
+    }
     return success;
 }
 #endif /* VM */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -533,16 +533,15 @@ struct ELF64_hdr {                     // 실행파일을 위한 파일 형식
 };
 
 struct ELF64_PHDR {
-    uint32_t p_type;
-    uint32_t p_flags;
-    uint64_t p_offset;
-    uint64_t p_vaddr;
-    uint64_t p_paddr;
-    uint64_t p_filesz;
-    uint64_t p_memsz;
-    uint64_t p_align;
+    uint32_t p_type;     // 세그먼트 타입 (Segment type)
+    uint32_t p_flags;    // 세그먼트 플래그 (Segment flags)
+    uint64_t p_offset;   // 파일 오프셋 (File offset)
+    uint64_t p_vaddr;    // 가상 주소 (Virtual address)
+    uint64_t p_paddr;    // 물리 주소 (Physical address)
+    uint64_t p_filesz;   // 파일 내 크기 (Size in file)
+    uint64_t p_memsz;    // 메모리 내 크기 (Size in memory)
+    uint64_t p_align;    // 정렬 (Alignment)
 };
-
 /* 약어 */
 /* Abbreviations */
 #define ELF ELF64_hdr
@@ -556,10 +555,6 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage, uint32_t 
  * 실행 가능한 진입점을 *RIP에 저장하고
  * 초기 스택 포인터를 *RSP에 저장합니다.
  * 성공하면 true를 반환하고, 그렇지 않으면 false를 반환합니다. */
-/* Loads an ELF executable from FILE_NAME into the current thread.
- * Stores the executable's entry point into *RIP
- * and its initial stack pointer into *RSP.
- * Returns true if successful, false otherwise. */
 static bool load(const char *file_name, struct intr_frame *if_) {
     process_init();
     struct thread *t = thread_current();
@@ -570,15 +565,12 @@ static bool load(const char *file_name, struct intr_frame *if_) {
     int i;
 
     /* 페이지 디렉터리를 할당하고 활성화합니다. */
-    /* Allocate and activate page directory. */
     t->pml4 = pml4_create(); // 페이지 디렉토리 생성
     if (t->pml4 == NULL)
         goto done;
     process_activate(thread_current()); // 페이지 테이블 활성화
 
     /* (프로그램 파일) 실행 파일을 엽니다. */
-    /* Open executable file. */
-    
     lock_acquire(&filesys_lock);
     file = filesys_open(file_name);
     if (file == NULL) {
@@ -591,7 +583,6 @@ static bool load(const char *file_name, struct intr_frame *if_) {
     lock_release(&filesys_lock);
 
     /* 실행 가능한 헤더를 읽고 확인합니다. */
-    /* Read and verify executable header. */
     if (file_read(file, &ehdr, sizeof ehdr) != sizeof ehdr || memcmp(ehdr.e_ident, "\177ELF\2\1\1", 7) || ehdr.e_type != 2 || ehdr.e_machine != 0x3E  // amd64
         || ehdr.e_version != 1 || ehdr.e_phentsize != sizeof(struct Phdr) || ehdr.e_phnum > 1024) {
         printf("load: %s: error loading executable\n", file_name);
@@ -599,7 +590,6 @@ static bool load(const char *file_name, struct intr_frame *if_) {
     }
 
     /* 프로그램 헤더를 읽습니다. */
-    /* Read program headers. */
     file_ofs = ehdr.e_phoff;
     for (i = 0; i < ehdr.e_phnum; i++) {
         struct Phdr phdr;
@@ -618,7 +608,6 @@ static bool load(const char *file_name, struct intr_frame *if_) {
             case PT_STACK:
             default:
                 /* 이 세그먼트를 무시합니다. */
-                /* Ignore this segment. */
                 break;
             case PT_DYNAMIC:
             case PT_INTERP:
@@ -634,15 +623,11 @@ static bool load(const char *file_name, struct intr_frame *if_) {
                     if (phdr.p_filesz > 0) {
                         /* 일반적인 세그먼트.
                          * 디스크에서 초기 부분을 읽고 나머지는 0으로 설정합니다. */
-                        /* Normal segment.
-                         * Read initial part from disk and zero the rest. */
                         read_bytes = page_offset + phdr.p_filesz;
                         zero_bytes = (ROUND_UP(page_offset + phdr.p_memsz, PGSIZE) - read_bytes);
                     } else {
-                        /* 완전히 0입니다.
+                        /* 완전히 0입니다
                          * 디스크에서 아무 것도 읽지 않습니다. */
-                        /* Entirely zero.
-                         * Don't read anything from disk. */
                         read_bytes = 0;
                         zero_bytes = ROUND_UP(page_offset + phdr.p_memsz, PGSIZE);
                     }
@@ -655,18 +640,14 @@ static bool load(const char *file_name, struct intr_frame *if_) {
     }
 
     /* 스택 설정 */
-    /* Set up stack. */
     if (!setup_stack(if_))
         goto done;
 
     /* 시작 주소 */
-    /* Start address. */
     if_->rip = ehdr.e_entry;
 
     /* TODO: 여기에 코드를 작성하세요.
      * TODO: 인자 전달을 구현하세요 (참조: project2/argument_passing.html). */
-    /* TODO: Your code goes here.
-     * TODO: Implement argument passing (see project2/argument_passing.html). */
 
     success = true;
 
@@ -859,18 +840,15 @@ static bool install_page(void *upage, void *kpage, bool writable) {
 #else
 /* 여기부터는 프로젝트 3 이후에 사용될 코드입니다.
  * 프로젝트 2만을 위해 함수를 구현하려면 위 블록에 구현하세요. */
-/* From here, codes will be used after project 3.
- * If you want to implement the function for only project 2, implement it on the
- * upper block. */
-
+/* Project 3: Anonymous Page - uninit 페이지에 처음 접근하여 페이지 폴트가 발생하면 lazy_load_segment가 실행되어 물리 메모리에 파일 내용이 올라간다. */
 static bool lazy_load_segment(struct page *page, void *aux) {
     /* TODO: 파일에서 세그먼트를 로드합니다. */
     /* TODO: 이 함수는 주소 VA에서 처음 페이지 폴트가 발생할 때 호출됩니다. */
     /* TODO: 호출하는 동안 VA를 사용할 수 있습니다. */
 
-    /* TODO: Load the segment from the file */
-    /* TODO: This called when the first page fault occurs on address VA. */
-    /* TODO: VA is available when calling this function. */
+
+
+    
 }
 
 /* Loads a segment starting at offset OFS in FILE at address
@@ -888,6 +866,8 @@ static bool lazy_load_segment(struct page *page, void *aux) {
  * Return true if successful, false if a memory allocation error
  * or disk read error occurs. */
 static bool load_segment(struct file *file, off_t ofs, uint8_t *upage, uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
+    // file_page는 offset이고
+    // mem_page는 upage이다.
     ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
     ASSERT(pg_ofs(upage) == 0);
     ASSERT(ofs % PGSIZE == 0);

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -28,6 +28,10 @@ vm_anon_init (void) {
 bool
 anon_initializer (struct page *page, enum vm_type type, void *kva) {
 	/* Set up the handler */
+	/* 데이터를 모두 0으로 초기화 */
+	struct uninit_page *uninit = &page->uninit;
+    memset(uninit, 0, sizeof(struct uninit_page));
+
 	page->operations = &anon_ops;
 
 	struct anon_page *anon_page = &page->anon;

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -170,7 +170,7 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	struct page *page = NULL;
 	/* TODO: Validate the fault */
 	/* TODO: Your code goes here */
-	page = spt_find_page(&thread_current()->spt, addr);
+	page = spt_find_page(spt, addr);
 	
 	/* TODO: Validate the fault */
     if (addr == NULL || is_kernel_vaddr(addr))
@@ -209,11 +209,12 @@ vm_do_claim_page (struct page *page) {
 	page->frame = frame;
 
 	/* TODO: Insert page table entry to map page's VA to frame's PA. */
-    if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable)){
-		palloc_free_page(frame->kva);
-		return false;
-	}
-	return swap_in (page, frame->kva);
+    if (frame->page != NULL) {
+        if (!pml4_set_page(thread_current()->pml4,page->va,frame->kva,page->writable))
+            return false;
+    }
+ 
+    return swap_in(page, frame->kva);
 }
 
 /* Initialize new supplemental page table */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -167,6 +167,11 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	struct page *page = NULL;
 	/* TODO: Validate the fault */
 	/* TODO: Your code goes here */
+	page = spt_find_page(&thread_current()->spt, addr);
+	
+	/* TODO: Validate the fault */
+    if (addr == NULL || is_kernel_vaddr(addr))
+        return false;
 
 	return vm_do_claim_page (page);
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -74,6 +74,8 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		/* init은 lazy_load_segment함수이고 이 함수는 페이지 폴트 핸들러에서 호출되어야 함 */
 		uninit_new(p, upage, init, type, aux, page_initializer);
 		p->writable = writable;
+		/* TODO: Insert the page into the spt. */
+        return spt_insert_page(spt, p);
 	}
 err:
 	return false;

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -145,6 +145,7 @@ vm_get_frame (void) {
 
 	frame -> kva = palloc_get_page(PAL_USER);
 
+	frame->page = NULL;
 	ASSERT (frame != NULL);
 	ASSERT (frame->page == NULL);
 	return frame;


### PR DESCRIPTION
- [x] vm_alloc_page_with_initializer
- [x] setup_stack
- [x] lazy_load_segment
- [x] anon_initializer
- [x] vm_try_handle_fault 
- [x] vm_get_frame 수정  
- [x] load_segment 수정
- [x] running file reopen 수정
- [x] exit 위치 수정

pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
FAIL tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
FAIL tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
FAIL tests/userprog/exec-once
FAIL tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
FAIL tests/vm/pt-grow-stack
FAIL tests/vm/pt-grow-bad
FAIL tests/vm/pt-big-stk-obj
FAIL tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
FAIL tests/vm/pt-write-code
FAIL tests/vm/pt-write-code2
FAIL tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
FAIL tests/vm/page-parallel
FAIL tests/vm/page-merge-seq
FAIL tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
FAIL tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
FAIL tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
FAIL tests/vm/mmap-misalign
FAIL tests/vm/mmap-null
FAIL tests/vm/mmap-over-code
FAIL tests/vm/mmap-over-data
FAIL tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
FAIL tests/vm/mmap-zero
FAIL tests/vm/mmap-bad-fd2
FAIL tests/vm/mmap-bad-fd3
FAIL tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
FAIL tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
64 of 141 tests failed.
