### PR TITLE
Anonymous page fork

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,8 +3,8 @@
     {
       "type": "gdb",
       "request": "attach",
-      "name": "Attach to gdbserver : userprog",
-      "executable": "${workspaceRoot}/userprog/build/kernel.o",
+      "name": "Attach to gdbserver : vm",
+      "executable": "${workspaceRoot}/vm/build/kernel.o",
       "target": "localhost:1234",
       "remote": true,
       "cwd": "${workspaceRoot}",

--- a/include/lib/kernel/hash.h
+++ b/include/lib/kernel/hash.h
@@ -98,5 +98,5 @@ uint64_t hash_string (const char *);
 uint64_t hash_int (int);
 uint64_t hash_function (const struct hash_elem *e, void *aux);
 bool hash_less (const struct hash_elem *a, const struct hash_elem *b, void *aux);
-
+void hash_destructor(struct hash_elem *e, void *aux);
 #endif /* lib/kernel/hash.h */

--- a/lib/kernel/hash.c
+++ b/lib/kernel/hash.c
@@ -403,3 +403,10 @@ bool hash_less (const struct hash_elem *a, const struct hash_elem *b, void *aux)
 	const struct page *b_page = hash_entry(b, struct page, hash_elem);
 	return a_page->va < b_page->va;
 }
+
+/** Project 3: Anonymous Page - 해시 파괴 */
+void hash_destructor(struct hash_elem *e, void *aux) {
+    const struct page *p = hash_entry(e, struct page, hash_elem);
+    destroy(p);
+    free(p);
+}

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -194,8 +194,7 @@ page_fault (struct intr_frame *f) {
 #endif
 
 	/* userprog 테스트 케이스 통과 위해 exit(-1)로 종료합니다. */
-	if ( fault_addr == NULL || !is_user_vaddr(fault_addr))
-		exit(-1);
+	exit(-1);
 
 	/* 페이지 폴트 횟수를 셉니다. */
 	/* Count page faults. */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -140,8 +140,11 @@ void check_address(void *addr) {
 
     if (addr == NULL || !is_user_vaddr(addr))  // 사용자 영역 주소인지 확인
         exit(-1);
-    if (pml4_get_page(t->pml4, addr) == NULL)  // 페이지로 할당된 영역인지 확인
-        exit(-1);
+    if (pml4_get_page(t->pml4, addr) == NULL) { // 페이지로 할당된 영역인지 확인
+        if(!vm_claim_page(addr)){   // 해당 주소가 페이지에 존재하면 kva 매핑
+            exit(-1);
+        }
+    } 
 }
 
 /* fd로 file 주소를 반환하는 함수 */

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -53,4 +53,11 @@ anon_swap_out (struct page *page) {
 static void
 anon_destroy (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+
+    /** Project 3: Anonymous Page - 점거중인 frame 삭제 */
+    if (page->frame) {
+        page->frame->page = NULL;
+        free(page->frame);
+        page->frame = NULL;
+    }
 }


### PR DESCRIPTION
- [x] supplemental_page_table_copy
- [x] supplemental_page_table_kill
- [x] anon_destroy 

pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
FAIL tests/vm/pt-grow-stack
FAIL tests/vm/pt-grow-bad
FAIL tests/vm/pt-big-stk-obj
FAIL tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
FAIL tests/vm/pt-write-code
FAIL tests/vm/pt-write-code2
FAIL tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
pass tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
FAIL tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
FAIL tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
FAIL tests/vm/mmap-misalign
FAIL tests/vm/mmap-null
FAIL tests/vm/mmap-over-code
FAIL tests/vm/mmap-over-data
FAIL tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
FAIL tests/vm/mmap-zero
FAIL tests/vm/mmap-bad-fd2
FAIL tests/vm/mmap-bad-fd3
FAIL tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
FAIL tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
40 of 141 tests failed.