### PR TITLE
Fix/file backed destroy

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -70,6 +70,7 @@ struct frame {
 
 	/** Project 3: Memory Management - 리스트 객체 추가  */
     struct list_elem frame_elem;
+	int reference_cnt;
 };
 
 /* The function table for page operations.

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -234,7 +234,6 @@ int write(int fd, const void *buffer, unsigned size) {
     // 해당 버퍼가 code segment일지라도 buffer의 값이 변경되는 게 아님.
     // 해당 버퍼값으로 파일에 입력하는 것일뿐이므로 validation 필요 없음.
     check_valid_buffer(buffer, size, false);
-    check_address(buffer);
     struct file *file = fd_to_fileptr(fd);
     int result;
 
@@ -304,7 +303,6 @@ int read(int fd, void *buffer, unsigned size) {
     // 해당 버퍼가 code segment일 경우, 해당 버퍼에 쓰이면 안됨.
     // 검증이 필요하므로 validation을 true로 함
     check_valid_buffer(buffer, size, true);
-    check_address(buffer);
 
     // fd가 0이면 (stdin) input_getc()를 사용해서 키보드 입력을 읽고 버퍼에 저장(?)
     if (fd == 0) {

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -56,6 +56,7 @@ anon_destroy (struct page *page) {
 
     /** Project 3: Anonymous Page - 점거중인 frame 삭제 */
     if (page->frame) {
+		list_remove(&page->frame->frame_elem);
         page->frame->page = NULL;
         free(page->frame);
         page->frame = NULL;

--- a/vm/file.c
+++ b/vm/file.c
@@ -118,10 +118,16 @@ err:
 void do_munmap(void *addr) {
     struct thread *curr = thread_current();
     struct page *page;
-
+    struct file *file;
+    page = spt_find_page(&curr->spt, addr);
+    if (page){
+        file = page->file.file;
+    }
+    
     while (page = spt_find_page(&curr->spt, addr)) {
         destroy(page);
-
         addr += PGSIZE;
     }
+
+    file_close(file);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -59,7 +59,18 @@ static void file_backed_destroy(struct page *page) {
         file_write_at(file_page->file, page->va, file_page->page_read_bytes, file_page->offset);
         pml4_set_dirty(thread_current()->pml4, page->va, false);
     }
-    pml4_clear_page(thread_current()->pml4, page->va);
+ 
+    if (page->frame){
+        if (page->frame->reference_cnt > 1) {
+            page->frame->reference_cnt -= 1;
+            pml4_clear_page(thread_current()->pml4, page->va);
+        } else {
+            list_remove(&page->frame->frame_elem);
+            page->frame->page = NULL;
+            free(page->frame);
+            page->frame = NULL;
+        }
+    }
 }
 
 /** Project 3: Memory Mapped Files - Memory Mapping - Do the mmap */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -149,6 +149,7 @@ static struct frame *vm_evict_frame(void) {
 static struct frame *vm_get_frame(void) {
     /* TODO: Fill this function. */
     struct frame *frame = (struct frame *)malloc(sizeof(struct frame));
+	frame->reference_cnt = 1;
     ASSERT(frame != NULL);
 
     frame->kva = palloc_get_page(PAL_USER);  // 유저 풀(실제 메모리)에서 페이지를 할당 받는다.
@@ -299,6 +300,7 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, st
                 if (!file_backed_initializer(dst_page, type, NULL))
                     goto err;
 
+				src_page->frame->reference_cnt += 1;
                 dst_page->frame = src_page->frame;
                 if (!pml4_set_page(thread_current()->pml4, dst_page->va, src_page->frame->kva, src_page->writable))
                     goto err;


### PR DESCRIPTION
- [x] reopen한 파일 close 시켜줌
- [x]  file page destory시 frame 삭제 추가, 참조하는 프로세스가 있는 경우 맵핑만 끊어서 kpa 안 지워지도록 처리


pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
pass tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
pass tests/vm/page-merge-par
pass tests/vm/page-merge-stk
pass tests/vm/page-merge-mm
pass tests/vm/page-shuffle
pass tests/vm/mmap-read
pass tests/vm/mmap-close
pass tests/vm/mmap-unmap
pass tests/vm/mmap-overlap
pass tests/vm/mmap-twice
pass tests/vm/mmap-write
pass tests/vm/mmap-ro
pass tests/vm/mmap-exit
pass tests/vm/mmap-shuffle
pass tests/vm/mmap-bad-fd
pass tests/vm/mmap-clean
pass tests/vm/mmap-inherit
pass tests/vm/mmap-misalign
pass tests/vm/mmap-null
pass tests/vm/mmap-over-code
pass tests/vm/mmap-over-data
pass tests/vm/mmap-over-stk
pass tests/vm/mmap-remove
pass tests/vm/mmap-zero
pass tests/vm/mmap-bad-fd2
pass tests/vm/mmap-bad-fd3
pass tests/vm/mmap-zero-len
pass tests/vm/mmap-off
pass tests/vm/mmap-bad-off
pass tests/vm/mmap-kernel
pass tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
5 of 141 tests failed.