### PR TITLE
Swap in out

### DIFF
--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -5,6 +5,7 @@ struct page;
 enum vm_type;
 
 struct anon_page {
+    size_t sector;
 };
 
 void vm_anon_init (void);

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -4,10 +4,12 @@
 #include "vm/vm.h"
 #include "devices/disk.h"
 #include "threads/vaddr.h"
+#include "threads/mmu.h"
 
 /** Project 3: Swap In/Out - 한 페이지를 섹터 단위로 관리 */
 #define SECTOR_SIZE (PGSIZE / DISK_SECTOR_SIZE)
-
+size_t swap_size;
+struct bitmap *swap_table;
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
@@ -31,10 +33,10 @@ vm_anon_init (void) {
     /* disk_size는 섹터를 반환함. 섹터 1개당 512byte임.
 	 * 우리는 페이지 단위로 swap in out을 진행할 것임. 
 	 * 섹터 8개 = 페이지 이므로 8로 나누면 swap_size는 페이지 단위 개수로 환산됨. */
-	size_t swap_size = disk_size(swap_disk) / SECTOR_SIZE;
+	swap_size = disk_size(swap_disk) / SECTOR_SIZE;
 
 	/* 페이지 단위로 swap in out 진행하므로 페이지 수만큼 비트를 생성해줌. */
-    struct bitmap *swap_table = bitmap_create(swap_size);
+	swap_table = bitmap_create(swap_size);
 }
 
 /* Initialize the file mapping */
@@ -48,24 +50,81 @@ anon_initializer (struct page *page, enum vm_type type, void *kva) {
 	page->operations = &anon_ops;
 
 	struct anon_page *anon_page = &page->anon;
+
+	/** Project 3: Swap In/Out - ERROR로 초기화  */
+    anon_page->sector = BITMAP_ERROR;
+
+    return true;
 }
 
-/* Swap in the page by read contents from the swap disk. */
+/** Project 3: Swap In/Out - Swap in the page by read contents from the swap disk. */
 static bool
-anon_swap_in (struct page *page, void *kva) {
-	struct anon_page *anon_page = &page->anon;
+anon_swap_in(struct page *page, void *kva) {
+    struct anon_page *anon_page = &page->anon;
+    size_t sector = anon_page->sector;
+    size_t slot = sector / SECTOR_SIZE;
+
+    if (sector == BITMAP_ERROR || !bitmap_test(swap_table, slot))
+        return false;
+
+    bitmap_set(swap_table, slot, false);
+
+    for (size_t i = 0; i < SECTOR_SIZE; i++)
+        disk_read(swap_disk, sector + i, kva + DISK_SECTOR_SIZE * i);
+
+    sector = BITMAP_ERROR;
+
+    return true;
 }
 
-/* Swap out the page by writing contents to the swap disk. */
+/** Project 3: Swap In/Out - Swap out the page by writing contents to the swap disk. */
 static bool
 anon_swap_out (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+
+	size_t free_idx = bitmap_scan_and_flip (swap_table, 0, 1, false);
+
+	if (free_idx == BITMAP_ERROR)
+		return false;
+
+	// disk는 sector단위로 관리
+	// os가 관리하는 비트맵은 sector 8개 단위로 관리
+	size_t sector = free_idx * SECTOR_SIZE;
+
+	for (size_t i = 0; i < SECTOR_SIZE; i++)
+		disk_write(swap_disk, sector + i, page->va + DISK_SECTOR_SIZE * i);
+
+	anon_page->sector = sector;
+
+	// disk에 기록했으니 pte 정보는 삭제해서 메모리 효율을 높여야 함
+    uint64_t pte = pml4e_walk(thread_current()->pml4, page->va, false);
+	if (((uint64_t)pte) & PTE_P)
+		palloc_free_page((void *)PTE_ADDR(pte));
+
+	pml4_clear_page(thread_current()->pml4, page->va);
+    if (page->frame){
+		// 기존에 있던 프레임의 page, frame 간의 맵핑을 지우고
+		// 새로운 page를 frame에 이후에 할당해줘야함
+		// 그러니 해당 프레임 메모리를 없애면 안됨
+		// list_remove(&page->frame->frame_elem);
+		page->frame->page = NULL;
+		// free(page->frame);
+		page->frame = NULL;
+	}
+
+
+	return true;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
 static void
 anon_destroy (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+
+    /** Project 3: Swap In/Out - 점거중인 bitmap 삭제 */
+    if (anon_page->sector != BITMAP_ERROR)
+        bitmap_reset(swap_table, anon_page->sector / SECTOR_SIZE);
+
 
     /** Project 3: Anonymous Page - 점거중인 frame 삭제 */
     if (page->frame) {

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -1,7 +1,13 @@
 /* anon.c: Implementation of page for non-disk image (a.k.a. anonymous page). */
+#include <bitmap.h>
 
 #include "vm/vm.h"
 #include "devices/disk.h"
+#include "threads/vaddr.h"
+
+/** Project 3: Swap In/Out - 한 페이지를 섹터 단위로 관리 */
+#define SECTOR_SIZE (PGSIZE / DISK_SECTOR_SIZE)
+
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
@@ -21,7 +27,14 @@ static const struct page_operations anon_ops = {
 void
 vm_anon_init (void) {
 	/* TODO: Set up the swap_disk. */
-	swap_disk = NULL;
+	swap_disk = disk_get(1,1);
+    /* disk_size는 섹터를 반환함. 섹터 1개당 512byte임.
+	 * 우리는 페이지 단위로 swap in out을 진행할 것임. 
+	 * 섹터 8개 = 페이지 이므로 8로 나누면 swap_size는 페이지 단위 개수로 환산됨. */
+	size_t swap_size = disk_size(swap_disk) / SECTOR_SIZE;
+
+	/* 페이지 단위로 swap in out 진행하므로 페이지 수만큼 비트를 생성해줌. */
+    struct bitmap *swap_table = bitmap_create(swap_size);
 }
 
 /* Initialize the file mapping */

--- a/vm/file.c
+++ b/vm/file.c
@@ -44,12 +44,24 @@ file_backed_initializer(struct page *page, enum vm_type type, void *kva) {
 static bool
 file_backed_swap_in (struct page *page, void *kva) {
 	struct file_page *file_page UNUSED = &page->file;
+
+    return lazy_load_segment(page, file_page);
 }
 
 /* Swap out the page by writeback contents to the file. */
 static bool
 file_backed_swap_out (struct page *page) {
 	struct file_page *file_page UNUSED = &page->file;
+    if (pml4_is_dirty(thread_current()->pml4, page->va)) {
+        file_write_at(file_page->file, page->va, file_page->page_read_bytes, file_page->offset);
+        pml4_set_dirty(thread_current()->pml4, page->va, false);
+    }
+
+    page->frame->page = NULL;
+    page->frame = NULL;
+    pml4_clear_page(thread_current()->pml4, page->va);
+
+    return true;
 }
 
 /* Destory the file backed page. PAGE will be freed by the caller. */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -210,7 +210,7 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		return false;
 	}
 	
-	if (write == vm_handle_wp)  // write protected 인데 write 요청한 경우
+	if (write & vm_handle_wp(page))  // write protected 인데 write 요청한 경우
         return false;
 
 	return vm_do_claim_page(page);


### PR DESCRIPTION
- [x] anon swap in/out
- [x] file swap in/out

pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
pass tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
pass tests/vm/page-merge-par
pass tests/vm/page-merge-stk
pass tests/vm/page-merge-mm
pass tests/vm/page-shuffle
pass tests/vm/mmap-read
pass tests/vm/mmap-close
pass tests/vm/mmap-unmap
pass tests/vm/mmap-overlap
pass tests/vm/mmap-twice
pass tests/vm/mmap-write
pass tests/vm/mmap-ro
pass tests/vm/mmap-exit
pass tests/vm/mmap-shuffle
pass tests/vm/mmap-bad-fd
pass tests/vm/mmap-clean
pass tests/vm/mmap-inherit
pass tests/vm/mmap-misalign
pass tests/vm/mmap-null
pass tests/vm/mmap-over-code
pass tests/vm/mmap-over-data
pass tests/vm/mmap-over-stk
pass tests/vm/mmap-remove
pass tests/vm/mmap-zero
pass tests/vm/mmap-bad-fd2
pass tests/vm/mmap-bad-fd3
pass tests/vm/mmap-zero-len
pass tests/vm/mmap-off
pass tests/vm/mmap-bad-off
pass tests/vm/mmap-kernel
pass tests/vm/lazy-file
pass tests/vm/lazy-anon
pass tests/vm/swap-file
pass tests/vm/swap-anon
pass tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
2 of 141 tests failed.